### PR TITLE
be more aggressive about cleaning out jobs that have finished

### DIFF
--- a/iceprod/server/plugins/condor.py
+++ b/iceprod/server/plugins/condor.py
@@ -920,7 +920,7 @@ class Grid(grid.BaseGrid):
                     logger.debug('stat: %r', st)
                     if stat.S_ISDIR(st.st_mode):
                         empty = False
-                        if job_active:
+                        if not job_active:
                             if st.st_mtime < job_clean_logs_time:
                                 logger.info('cleaning up submit dir %s', path)
                                 shutil.rmtree(path)

--- a/iceprod/server/plugins/condor.py
+++ b/iceprod/server/plugins/condor.py
@@ -95,6 +95,7 @@ RESET_STDERR_REASONS = [
     'sigterm',
     'killed',
     'bus error (core dumped)',
+    'segmentation fault (core dumped)',
     'operation timed out',
     'connection timed out',
 ]
@@ -898,25 +899,32 @@ class Grid(grid.BaseGrid):
         Return directory paths that should be cleaned up.
         """
         # get time limits
+        queue_tasks = {j.task_id for j in self.jobs.values()}
         queued_time = self.cfg['queue'].get('max_task_queued_time', 86400*2)
         processing_time = self.cfg['queue'].get('max_task_processing_time', 86400*2)
         suspend_time = self.cfg['queue'].get('suspend_submit_dir_time', 86400)
         now = time.time()
+        job_clean_logs_time = now - suspend_time
         job_old_time = now - (queued_time + processing_time)
         dir_old_time = now - (queued_time + processing_time + suspend_time)
-        logger.debug('now: %r, job_old_time: %r, dir_old_time: %r', now, job_old_time, dir_old_time)
+        logger.debug('now: %r, job_clean_logs_time: %r, job_old_time: %r, dir_old_time: %r', now, job_clean_logs_time, job_old_time, dir_old_time)
 
         for daydir in self.submit_dir.glob('[0-9][0-9][0-9][0-9]*'):
             logger.debug('looking at daydir %s', daydir)
             if daydir.is_dir():
                 empty = True
                 for path in daydir.iterdir():
-                    logger.debug('looking at path %s', path)
+                    job_active = path.name.split('_')[0] in queue_tasks
+                    logger.debug('looking at path %s, active: %r', path, job_active)
                     st = path.lstat()
                     logger.debug('stat: %r', st)
                     if stat.S_ISDIR(st.st_mode):
                         empty = False
-                        if st.st_mtime < job_old_time:
+                        if job_active:
+                            if st.st_mtime < job_clean_logs_time:
+                                logger.info('cleaning up submit dir %s', path)
+                                shutil.rmtree(path)
+                        elif st.st_mtime < job_old_time:
                             yield path
                             if st.st_mtime < dir_old_time:
                                 logger.info('cleaning up submit dir %s', path)

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -16,9 +16,9 @@ attrs==24.2.0
     #   referencing
 babel==2.16.0
     # via sphinx
-boto3==1.35.48
+boto3==1.35.49
     # via iceprod (setup.py)
-botocore==1.35.48
+botocore==1.35.49
     # via
     #   boto3
     #   s3transfer

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -16,9 +16,9 @@ attrs==24.2.0
     #   referencing
 babel==2.16.0
     # via sphinx
-boto3==1.35.45
+boto3==1.35.48
     # via iceprod (setup.py)
-botocore==1.35.45
+botocore==1.35.48
     # via
     #   boto3
     #   s3transfer

--- a/requirements-tests.txt
+++ b/requirements-tests.txt
@@ -14,11 +14,11 @@ attrs==24.2.0
     #   referencing
 beautifulsoup4==4.12.3
     # via iceprod (setup.py)
-boto3==1.35.48
+boto3==1.35.49
     # via
     #   iceprod (setup.py)
     #   moto
-botocore==1.35.48
+botocore==1.35.49
     # via
     #   boto3
     #   moto
@@ -216,7 +216,7 @@ urllib3==2.2.3
     #   responses
     #   types-requests
     #   wipac-rest-tools
-werkzeug==3.0.5
+werkzeug==3.0.6
     # via moto
 wipac-dev-tools==1.13.0
     # via

--- a/requirements-tests.txt
+++ b/requirements-tests.txt
@@ -14,11 +14,11 @@ attrs==24.2.0
     #   referencing
 beautifulsoup4==4.12.3
     # via iceprod (setup.py)
-boto3==1.35.45
+boto3==1.35.48
     # via
     #   iceprod (setup.py)
     #   moto
-botocore==1.35.45
+botocore==1.35.48
     # via
     #   boto3
     #   moto
@@ -216,7 +216,7 @@ urllib3==2.2.3
     #   responses
     #   types-requests
     #   wipac-rest-tools
-werkzeug==3.0.4
+werkzeug==3.0.5
     # via moto
 wipac-dev-tools==1.13.0
     # via

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,9 +12,9 @@ attrs==24.2.0
     # via
     #   jsonschema
     #   referencing
-boto3==1.35.48
+boto3==1.35.49
     # via iceprod (setup.py)
-botocore==1.35.48
+botocore==1.35.49
     # via
     #   boto3
     #   s3transfer

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,9 +12,9 @@ attrs==24.2.0
     # via
     #   jsonschema
     #   referencing
-boto3==1.35.45
+boto3==1.35.48
     # via iceprod (setup.py)
-botocore==1.35.45
+botocore==1.35.48
     # via
     #   boto3
     #   s3transfer


### PR DESCRIPTION
Previously we just waited the max time for a job to possibly be running + some extra time for debugging after a job runs.  Now, if a job is no longer on the queue, only wait the debugging time before cleaning it up.