### PR TITLE
fix materialization case where job gets created and service is killed

### DIFF
--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -16,9 +16,9 @@ attrs==24.2.0
     #   referencing
 babel==2.16.0
     # via sphinx
-boto3==1.35.49
+boto3==1.35.53
     # via iceprod (setup.py)
-botocore==1.35.49
+botocore==1.35.53
     # via
     #   boto3
     #   s3transfer
@@ -123,7 +123,7 @@ requests-futures==1.0.1
     #   wipac-rest-tools
 requests-toolbelt==1.0.0
     # via iceprod (setup.py)
-rpds-py==0.20.0
+rpds-py==0.20.1
     # via
     #   jsonschema
     #   referencing

--- a/requirements-tests.txt
+++ b/requirements-tests.txt
@@ -14,11 +14,11 @@ attrs==24.2.0
     #   referencing
 beautifulsoup4==4.12.3
     # via iceprod (setup.py)
-boto3==1.35.49
+boto3==1.35.53
     # via
     #   iceprod (setup.py)
     #   moto
-botocore==1.35.49
+botocore==1.35.53
     # via
     #   boto3
     #   moto
@@ -131,7 +131,7 @@ pytest==8.0.2
     #   pytest-mock
 pytest-asyncio==0.23.8
     # via iceprod (setup.py)
-pytest-cov==5.0.0
+pytest-cov==6.0.0
     # via iceprod (setup.py)
 pytest-mock==3.14.0
     # via iceprod (setup.py)
@@ -173,7 +173,7 @@ responses==0.25.3
     # via moto
 respx==0.21.1
     # via iceprod (setup.py)
-rpds-py==0.20.0
+rpds-py==0.20.1
     # via
     #   jsonschema
     #   referencing
@@ -216,7 +216,7 @@ urllib3==2.2.3
     #   responses
     #   types-requests
     #   wipac-rest-tools
-werkzeug==3.0.6
+werkzeug==3.1.0
     # via moto
 wipac-dev-tools==1.13.0
     # via

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,9 +12,9 @@ attrs==24.2.0
     # via
     #   jsonschema
     #   referencing
-boto3==1.35.49
+boto3==1.35.53
     # via iceprod (setup.py)
-botocore==1.35.49
+botocore==1.35.53
     # via
     #   boto3
     #   s3transfer
@@ -106,7 +106,7 @@ requests-futures==1.0.1
     #   wipac-rest-tools
 requests-toolbelt==1.0.0
     # via iceprod (setup.py)
-rpds-py==0.20.0
+rpds-py==0.20.1
     # via
     #   jsonschema
     #   referencing

--- a/tests/materialization/test_materialize.py
+++ b/tests/materialization/test_materialize.py
@@ -2,6 +2,7 @@ from unittest.mock import AsyncMock, MagicMock
 
 from rest_tools.client import RestClient
 
+import iceprod.materialization.materialize
 from iceprod.materialization.materialize import Materialize
 
 def test_materialize_init():
@@ -66,3 +67,121 @@ async def test_materialize_buffer_job_no_depends(requests_mock):
     ret = await m.buffer_job(dataset, 0)
 
     assert ret == 1
+
+
+async def test_materialize_buffer_job_incomplete(monkeypatch, requests_mock):
+    rc = RestClient('http://test.iceprod')
+    m = Materialize(rc)
+    config = {
+        'tasks': [
+            {
+                'name': 'foo',
+            },
+            {
+                'name': 'bar',
+            },
+            {
+                'name': 'baz',
+            }
+        ],
+        'options': {}
+    }
+    m.get_config = AsyncMock(return_value=config)
+    prio_mock = MagicMock()
+    monkeypatch.setattr('iceprod.materialization.materialize.Priority', prio_mock)
+    prio_mock.return_value.get_task_prio = AsyncMock(return_value=1.)
+
+    requests_mock.get('http://test.iceprod/datasets/did123', json={
+        'dataset_id': 'did123',
+        'dataset': 123,
+        'status': 'processing',
+        'tasks_per_job': 3,
+        'jobs_submitted': 10,
+        'tasks_submitted': 10,
+        'debug': False,
+    })
+    
+    requests_mock.get('http://test.iceprod/datasets/did123/job_counts/status', json={
+        'processing': 1,
+    })
+    requests_mock.get('http://test.iceprod/datasets/did123/task_counts/status', json={
+        'idle': 1,
+    })
+    requests_mock.get('http://test.iceprod/datasets/did123/jobs', json={
+        'j123': {
+            'job_id': 'j123',
+            'job_index': 0,
+        },
+    })
+    requests_mock.get('http://test.iceprod/datasets/did123/tasks', json={
+        't0': {
+            'task_id': 't0',
+            'job_id': 'j123',
+            'task_index': 0,
+        },
+    })
+
+    requests_mock.post('http://test.iceprod/jobs', json={'result': 'j2'})
+    requests_mock.post('http://test.iceprod/tasks', json={'result': 't0'})
+    requests_mock.patch('http://test.iceprod/tasks/t0', json={})
+
+    ret = await m.run_once(only_dataset='did123', num=0)
+
+    calls = [h for h in requests_mock.request_history if h.url == 'http://test.iceprod/tasks']
+    assert len(calls) == 2
+
+
+async def test_materialize_buffer_job_no_tasks(monkeypatch, requests_mock):
+    rc = RestClient('http://test.iceprod')
+    m = Materialize(rc)
+    config = {
+        'tasks': [
+            {
+                'name': 'foo',
+            },
+            {
+                'name': 'bar',
+            },
+            {
+                'name': 'baz',
+            }
+        ],
+        'options': {}
+    }
+    m.get_config = AsyncMock(return_value=config)
+    prio_mock = MagicMock()
+    monkeypatch.setattr('iceprod.materialization.materialize.Priority', prio_mock)
+    prio_mock.return_value.get_task_prio = AsyncMock(return_value=1.)
+
+    requests_mock.get('http://test.iceprod/datasets/did123', json={
+        'dataset_id': 'did123',
+        'dataset': 123,
+        'status': 'processing',
+        'tasks_per_job': 3,
+        'jobs_submitted': 10,
+        'tasks_submitted': 10,
+        'debug': False,
+    })
+    
+    requests_mock.get('http://test.iceprod/datasets/did123/job_counts/status', json={
+        'processing': 1,
+    })
+    requests_mock.get('http://test.iceprod/datasets/did123/task_counts/status', json={
+    })
+    requests_mock.get('http://test.iceprod/datasets/did123/jobs', json={
+        'j123': {
+            'job_id': 'j123',
+            'job_index': 0,
+        },
+    })
+    requests_mock.get('http://test.iceprod/datasets/did123/tasks', json={
+    })
+
+    requests_mock.post('http://test.iceprod/jobs', json={'result': 'j2'})
+    requests_mock.post('http://test.iceprod/tasks', json={'result': 't0'})
+    requests_mock.patch('http://test.iceprod/tasks/t0', json={})
+
+    ret = await m.run_once(only_dataset='did123', num=0)
+
+    calls = [h for h in requests_mock.request_history if h.url == 'http://test.iceprod/tasks']
+    assert len(calls) == 3


### PR DESCRIPTION
Specifically, when a job has no tasks because the service died between calls.

Also, add some test cases, the last of which failed before this change.

