### PR TITLE
do not use the JEL for completions, as the statistics are incomplete

### DIFF
--- a/iceprod/server/plugins/condor.py
+++ b/iceprod/server/plugins/condor.py
@@ -173,7 +173,7 @@ class CondorSubmit:
 
     _GENERIC_ADS = ['Iwd', 'IceProdDatasetId', 'IceProdTaskId', 'IceProdTaskInstanceId', 'MATCH_EXP_JOBGLIDEIN_ResourceName']
     AD_INFO = [
-        'RemotePool', 'RemoteHost', 'RemoteWallClockTime', 'ResidentSetSize_RAW', 'DiskUsage_RAW',
+        'RemotePool', 'RemoteHost', #'RemoteWallClockTime', 'ResidentSetSize_RAW', 'DiskUsage_RAW',
         'HoldReason', 'RemoveReason', 'Reason', 'MachineAttrGLIDEIN_Site0',
     ] + _GENERIC_ADS
     AD_PROJECTION_QUEUE = ['JobStatus', 'RemotePool', 'RemoteHost'] + _GENERIC_ADS

--- a/iceprod/server/plugins/condor.py
+++ b/iceprod/server/plugins/condor.py
@@ -681,6 +681,10 @@ class Grid(grid.BaseGrid):
                             if type_ == htcondor.JobEventType.JOB_TERMINATED:
                                 logger.info("job %s %s.%s exited on its own", job_id, job.dataset_id, job.task_id)
 
+                                # there's a bug where not all the classads are updated before the event fires
+                                # so ignore this and let the cross-check take care of it
+                                continue
+
                                 # get stats
                                 cpu = event.get('CpusUsage', None)
                                 gpu = event.get('GpusUsage', None)
@@ -734,6 +738,11 @@ class Grid(grid.BaseGrid):
                                 job.status = JobStatus.FAILED
                                 reason = event.get('Reason', None)
                                 logger.info("job %s %s.%s removed: %r", job_id, job.dataset_id, job.task_id, reason)
+
+                                # there's a bug where not all the classads are updated before the event fires
+                                # so ignore this and let the cross-check take care of it
+                                continue
+
                                 await self.finish(job_id, success=False, reason=reason)
 
                             else:

--- a/iceprod/server/plugins/condor.py
+++ b/iceprod/server/plugins/condor.py
@@ -173,7 +173,7 @@ class CondorSubmit:
 
     _GENERIC_ADS = ['Iwd', 'IceProdDatasetId', 'IceProdTaskId', 'IceProdTaskInstanceId', 'MATCH_EXP_JOBGLIDEIN_ResourceName']
     AD_INFO = [
-        'RemotePool', 'RemoteHost', #'RemoteWallClockTime', 'ResidentSetSize_RAW', 'DiskUsage_RAW',
+        'RemotePool', 'RemoteHost',
         'HoldReason', 'RemoveReason', 'Reason', 'MachineAttrGLIDEIN_Site0',
     ] + _GENERIC_ADS
     AD_PROJECTION_QUEUE = ['JobStatus', 'RemotePool', 'RemoteHost'] + _GENERIC_ADS

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -16,9 +16,9 @@ attrs==24.2.0
     #   referencing
 babel==2.16.0
     # via sphinx
-boto3==1.35.65
+boto3==1.35.66
     # via iceprod (setup.py)
-botocore==1.35.65
+botocore==1.35.66
     # via
     #   boto3
     #   s3transfer
@@ -127,7 +127,7 @@ rpds-py==0.21.0
     # via
     #   jsonschema
     #   referencing
-s3transfer==0.10.3
+s3transfer==0.10.4
     # via boto3
 setproctitle==1.3.4
     # via iceprod (setup.py)

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -16,9 +16,9 @@ attrs==24.2.0
     #   referencing
 babel==2.16.0
     # via sphinx
-boto3==1.35.61
+boto3==1.35.65
     # via iceprod (setup.py)
-botocore==1.35.61
+botocore==1.35.65
     # via
     #   boto3
     #   s3transfer
@@ -52,7 +52,7 @@ h11==0.14.0
     # via httpcore
 htcondor==24.1.1
     # via iceprod (setup.py)
-httpcore==1.0.6
+httpcore==1.0.7
     # via httpx
 httpx==0.27.2
     # via iceprod (setup.py)
@@ -89,7 +89,7 @@ pycparser==2.22
     # via cffi
 pygments==2.18.0
     # via sphinx
-pyjwt[crypto]==2.9.0
+pyjwt[crypto]==2.10.0
     # via wipac-rest-tools
 pymongo==4.9.2
     # via
@@ -117,7 +117,7 @@ requests==2.32.3
     #   sphinx
     #   wipac-dev-tools
     #   wipac-rest-tools
-requests-futures==1.0.1
+requests-futures==1.0.2
     # via
     #   iceprod (setup.py)
     #   wipac-rest-tools
@@ -129,7 +129,7 @@ rpds-py==0.21.0
     #   referencing
 s3transfer==0.10.3
     # via boto3
-setproctitle==1.3.3
+setproctitle==1.3.4
     # via iceprod (setup.py)
 six==1.16.0
     # via python-dateutil

--- a/requirements-tests.txt
+++ b/requirements-tests.txt
@@ -14,11 +14,11 @@ attrs==24.2.0
     #   referencing
 beautifulsoup4==4.12.3
     # via iceprod (setup.py)
-boto3==1.35.61
+boto3==1.35.65
     # via
     #   iceprod (setup.py)
     #   moto
-botocore==1.35.61
+botocore==1.35.65
     # via
     #   boto3
     #   moto
@@ -38,7 +38,7 @@ cffi==1.17.1
     # via cryptography
 charset-normalizer==3.4.0
     # via requests
-coverage[toml]==7.6.5
+coverage[toml]==7.6.7
     # via
     #   iceprod (setup.py)
     #   pytest-cov
@@ -62,7 +62,7 @@ h11==0.14.0
     # via httpcore
 htcondor==24.1.1
     # via iceprod (setup.py)
-httpcore==1.0.6
+httpcore==1.0.7
     # via httpx
 httpx==0.27.2
     # via
@@ -95,7 +95,7 @@ mccabe==0.7.0
     # via flake8
 mock==5.1.0
     # via iceprod (setup.py)
-moto[s3]==5.0.20
+moto[s3]==5.0.21
     # via iceprod (setup.py)
 motor==3.6.0
     # via iceprod (setup.py)
@@ -115,7 +115,7 @@ pycparser==2.22
     # via cffi
 pyflakes==3.2.0
     # via flake8
-pyjwt[crypto]==2.9.0
+pyjwt[crypto]==2.10.0
     # via wipac-rest-tools
 pymongo==4.9.2
     # via
@@ -161,7 +161,7 @@ requests==2.32.3
     #   responses
     #   wipac-dev-tools
     #   wipac-rest-tools
-requests-futures==1.0.1
+requests-futures==1.0.2
     # via
     #   iceprod (setup.py)
     #   wipac-rest-tools
@@ -179,7 +179,7 @@ rpds-py==0.21.0
     #   referencing
 s3transfer==0.10.3
     # via boto3
-setproctitle==1.3.3
+setproctitle==1.3.4
     # via iceprod (setup.py)
 six==1.16.0
     # via python-dateutil

--- a/requirements-tests.txt
+++ b/requirements-tests.txt
@@ -14,11 +14,11 @@ attrs==24.2.0
     #   referencing
 beautifulsoup4==4.12.3
     # via iceprod (setup.py)
-boto3==1.35.65
+boto3==1.35.66
     # via
     #   iceprod (setup.py)
     #   moto
-botocore==1.35.65
+botocore==1.35.66
     # via
     #   boto3
     #   moto
@@ -177,7 +177,7 @@ rpds-py==0.21.0
     # via
     #   jsonschema
     #   referencing
-s3transfer==0.10.3
+s3transfer==0.10.4
     # via boto3
 setproctitle==1.3.4
     # via iceprod (setup.py)

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,9 +12,9 @@ attrs==24.2.0
     # via
     #   jsonschema
     #   referencing
-boto3==1.35.61
+boto3==1.35.65
     # via iceprod (setup.py)
-botocore==1.35.61
+botocore==1.35.65
     # via
     #   boto3
     #   s3transfer
@@ -46,7 +46,7 @@ h11==0.14.0
     # via httpcore
 htcondor==24.1.1
     # via iceprod (setup.py)
-httpcore==1.0.6
+httpcore==1.0.7
     # via httpx
 httpx==0.27.2
     # via iceprod (setup.py)
@@ -73,7 +73,7 @@ pyasn1==0.6.1
     # via ldap3
 pycparser==2.22
     # via cffi
-pyjwt[crypto]==2.9.0
+pyjwt[crypto]==2.10.0
     # via wipac-rest-tools
 pymongo==4.9.2
     # via
@@ -100,7 +100,7 @@ requests==2.32.3
     #   requests-toolbelt
     #   wipac-dev-tools
     #   wipac-rest-tools
-requests-futures==1.0.1
+requests-futures==1.0.2
     # via
     #   iceprod (setup.py)
     #   wipac-rest-tools
@@ -112,7 +112,7 @@ rpds-py==0.21.0
     #   referencing
 s3transfer==0.10.3
     # via boto3
-setproctitle==1.3.3
+setproctitle==1.3.4
     # via iceprod (setup.py)
 six==1.16.0
     # via python-dateutil

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,9 +12,9 @@ attrs==24.2.0
     # via
     #   jsonschema
     #   referencing
-boto3==1.35.65
+boto3==1.35.66
     # via iceprod (setup.py)
-botocore==1.35.65
+botocore==1.35.66
     # via
     #   boto3
     #   s3transfer
@@ -110,7 +110,7 @@ rpds-py==0.21.0
     # via
     #   jsonschema
     #   referencing
-s3transfer==0.10.3
+s3transfer==0.10.4
     # via boto3
 setproctitle==1.3.4
     # via iceprod (setup.py)

--- a/tests/server/plugins/condor_test.py
+++ b/tests/server/plugins/condor_test.py
@@ -488,24 +488,24 @@ async def test_Grid_wait_JEL(schedd, i3prod_path, set_time):
 
     await g.wait(timeout=0)
 
-    assert len(g.jobs) == 7
+    #assert len(g.jobs) == 7
 
     assert g.jobs[CondorJobId(cluster_id=110828038, proc_id=0)].dataset_id == '4ksd8'
     assert g.jobs[CondorJobId(cluster_id=110828038, proc_id=0)].task_id == 'lnk3f'
     assert g.jobs[CondorJobId(cluster_id=110828038, proc_id=0)].submit_dir == Path('/scratch/dschultz')
-    assert g.jobs[CondorJobId(cluster_id=110828038, proc_id=0)].status == JobStatus.COMPLETED
+    #assert g.jobs[CondorJobId(cluster_id=110828038, proc_id=0)].status == JobStatus.COMPLETED
     
-    assert g.jobs[CondorJobId(cluster_id=110828038, proc_id=1)].status == JobStatus.COMPLETED
-    assert g.jobs[CondorJobId(cluster_id=110828038, proc_id=2)].status == JobStatus.COMPLETED
-    assert g.jobs[CondorJobId(cluster_id=110828038, proc_id=3)].status == JobStatus.FAILED
-    assert g.jobs[CondorJobId(cluster_id=110828038, proc_id=4)].status == JobStatus.FAILED
-    assert g.jobs[CondorJobId(cluster_id=110828038, proc_id=5)].status == JobStatus.COMPLETED
-    assert g.jobs[CondorJobId(cluster_id=110828038, proc_id=6)].status == JobStatus.FAILED
+    #assert g.jobs[CondorJobId(cluster_id=110828038, proc_id=1)].status == JobStatus.COMPLETED
+    #assert g.jobs[CondorJobId(cluster_id=110828038, proc_id=2)].status == JobStatus.COMPLETED
+    #assert g.jobs[CondorJobId(cluster_id=110828038, proc_id=3)].status == JobStatus.FAILED
+    #assert g.jobs[CondorJobId(cluster_id=110828038, proc_id=4)].status == JobStatus.FAILED
+    #assert g.jobs[CondorJobId(cluster_id=110828038, proc_id=5)].status == JobStatus.COMPLETED
+    #assert g.jobs[CondorJobId(cluster_id=110828038, proc_id=6)].status == JobStatus.FAILED
 
     assert g.task_idle.call_count == 1
     assert g.task_processing.call_count == 7
     assert g.task_reset.call_count == 0
-    assert g.finish.call_count == 6
+    #assert g.finish.call_count == 6
 
 
 async def test_Grid_wait_JEL_finish(schedd, i3prod_path, set_time):
@@ -527,14 +527,14 @@ async def test_Grid_wait_JEL_finish(schedd, i3prod_path, set_time):
 
     await g.wait(timeout=0)
 
-    assert len(g.jobs) == 1
-    assert list(g.jobs.keys()) == [CondorJobId(cluster_id=110828038, proc_id=4)]
+    #assert len(g.jobs) == 1
+    assert CondorJobId(cluster_id=110828038, proc_id=4) in g.jobs
 
     assert g.task_idle.call_count == 1
     assert g.task_processing.call_count == 7
     assert g.task_reset.call_count == 0
-    assert g.task_failure.call_count == 2
-    assert g.task_success.call_count == 4
+    #assert g.task_failure.call_count == 2
+    #assert g.task_success.call_count == 4
 
 
 async def test_Grid_wait_JEL_exception(schedd, i3prod_path, set_time):
@@ -556,14 +556,14 @@ async def test_Grid_wait_JEL_exception(schedd, i3prod_path, set_time):
 
     await g.wait(timeout=0)
 
-    assert len(g.jobs) == 1
-    assert list(g.jobs.keys()) == [CondorJobId(cluster_id=110828038, proc_id=4)]
+    #assert len(g.jobs) == 1
+    assert CondorJobId(cluster_id=110828038, proc_id=4) in g.jobs
 
     assert g.task_idle.call_count == 1
     assert g.task_processing.call_count == 7
     assert g.task_reset.call_count == 0
-    assert g.task_failure.call_count == 2
-    assert g.task_success.call_count == 4
+    #assert g.task_failure.call_count == 2
+    #assert g.task_success.call_count == 4
 
 
 async def test_Grid_wait_JEL_reprocess(schedd, i3prod_path, set_time):


### PR DESCRIPTION
An example:

from condor job event log for the job termination event:
```
RemoteWallClockTime = 28807.0
```

from condor_history:
```
RemoteWallClockTime = 275941.0
```

More details from condor_history:
```
CommittedSlotTime = 247121.0
CumulativeSlotTime = 275941.0
```

So it appears like during the job event it hasn't yet updated the `RemoteWallClockTime` classad, and the value is coming from previous job runs/evictions.