### PR TITLE
pin boto3 to before aws broke it for third parties

### DIFF
--- a/iceprod/scheduled_tasks/dataset_monitor.py
+++ b/iceprod/scheduled_tasks/dataset_monitor.py
@@ -45,6 +45,9 @@ async def process_dataset(rest_client, dataset_id):
     dataset = await rest_client.request('GET', f'/datasets/{dataset_id}')
     dataset_num = dataset['dataset']
     dataset_status = dataset['status']
+    if dataset_status != 'processing':
+        return
+
     with DatasetMonitorDuration.labels(name='dataset_monitor', dataset=str(dataset_num)).time():
         jobs = await rest_client.request('GET', f'/datasets/{dataset_id}/job_counts/status')
         jobs_counter = Counter()

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -16,9 +16,9 @@ attrs==25.1.0
     #   referencing
 babel==2.17.0
     # via sphinx
-boto3==1.36.15
+boto3==1.35.99
     # via iceprod (setup.py)
-botocore==1.36.15
+botocore==1.35.99
     # via
     #   boto3
     #   s3transfer
@@ -129,7 +129,7 @@ rpds-py==0.22.3
     # via
     #   jsonschema
     #   referencing
-s3transfer==0.11.2
+s3transfer==0.10.4
     # via boto3
 setproctitle==1.3.4
     # via iceprod (setup.py)

--- a/requirements-tests.txt
+++ b/requirements-tests.txt
@@ -14,11 +14,11 @@ attrs==25.1.0
     #   referencing
 beautifulsoup4==4.13.3
     # via iceprod (setup.py)
-boto3==1.36.15
+boto3==1.35.99
     # via
     #   iceprod (setup.py)
     #   moto
-botocore==1.36.15
+botocore==1.35.99
     # via
     #   boto3
     #   moto
@@ -179,7 +179,7 @@ rpds-py==0.22.3
     # via
     #   jsonschema
     #   referencing
-s3transfer==0.11.2
+s3transfer==0.10.4
     # via boto3
 setproctitle==1.3.4
     # via iceprod (setup.py)

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,9 +12,9 @@ attrs==25.1.0
     # via
     #   jsonschema
     #   referencing
-boto3==1.36.15
+boto3==1.35.99
     # via iceprod (setup.py)
-botocore==1.36.15
+botocore==1.35.99
     # via
     #   boto3
     #   s3transfer
@@ -112,7 +112,7 @@ rpds-py==0.22.3
     # via
     #   jsonschema
     #   referencing
-s3transfer==0.11.2
+s3transfer==0.10.4
     # via boto3
 setproctitle==1.3.4
     # via iceprod (setup.py)

--- a/setup.cfg
+++ b/setup.cfg
@@ -44,7 +44,7 @@ branch = master
 install_requires =
 	PyYAML
 	asyncache
-	boto3
+	boto3<1.36
 	cachetools
 	certifi
 	cryptography


### PR DESCRIPTION
* pin boto3 to last working version
* also stop monitoring old datasets to reduce cardinality 