### PR TITLE
fix weird heredoc login shell issues by defining the shell

### DIFF
--- a/iceprod/core/exe.py
+++ b/iceprod/core/exe.py
@@ -616,7 +616,7 @@ obj.Execute({{}})"""
 
         if module['env_clear']:
             # must be on cvmfs-like environ for this to apply
-            envstr = 'env -i PYTHONNOUSERSITE=1 '
+            envstr = 'env -i PYTHONNOUSERSITE=1 SHELL=/bin/sh '
             for k in ('OPENCL_VENDOR_PATH', 'http_proxy', 'TMP', 'TMPDIR', '_CONDOR_SCRATCH_DIR', 'CUDA_VISIBLE_DEVICES', 'COMPUTE', 'GPU_DEVICE_ORDINAL'):
                 envstr += f'{k}=${k} '
             cmd = envstr.split()+cmd


### PR DESCRIPTION
In particular, this can happen when someone defines their own env script to load a venv, like:
```bash
/cvmfs/icecube.opensciencegrid.org/py3-v4.4.1/icetray-env /cvmfs/icecube.opensciencegrid.org/users/my/icetray <<EOF
source /cvmfs/icecube.opensciencegrid.org/users/my/env/bin/activate
$@
EOF
```